### PR TITLE
fix : Only number is allowed in Room No

### DIFF
--- a/src/Components/HomePage.jsx
+++ b/src/Components/HomePage.jsx
@@ -26,10 +26,17 @@ const HomePage = () => {
   }, []);
 
   const handleChange = (e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+    
+        const value = e.target.value[e.target.value.length-1]
+        
+        if (/[0-9]/.test(value)||value==undefined) {
+          setFormData({
+            ...formData,
+            [e.target.name]: e.target.value,
+          });
+        }
+      
+    
   };
 
   const handleSubmit = (e) => {


### PR DESCRIPTION
Fixes Issue #99
The room no number input will now allow only numbers .
Before :

![Screenshot 2024-05-17 224055](https://github.com/urstrulynishkarsh/ReactChat/assets/118350936/cf6179bc-acdf-4dcd-8359-acc0839b4934)

After 



https://github.com/urstrulynishkarsh/ReactChat/assets/118350936/90aac4d3-01dc-4058-aeda-fd15705bcb77

