### PR TITLE
Send messages on right and receive on left side 🌟

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,7 +70,23 @@ circle:nth-child(3) {
 }
 
 .message {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  border-radius: 10px;
   margin-bottom: 16px;
+}
+
+.sent {
+  align-items: right;
+  background-color: #c1e3ff;
+  text-align: right;
+}
+
+.received {
+  align-items: right;
+  background-color: rgb(230, 230, 230);
+  text-align: left;
 }
 
 .message__name {
@@ -181,13 +197,12 @@ circle:nth-child(3) {
   border-radius: 4px;
   transform: translate(-50%, 0);
 }
-iframe{
+iframe {
   border-top: 10px solid #addff3;
   border-radius: 20px;
   border-bottom: 20px solid #addff3;
   border-left: 6px solid #addff3;
   border-right: 6px solid #addff3;
-
 }
 
 @keyframes circle-size {

--- a/src/App.css
+++ b/src/App.css
@@ -75,19 +75,19 @@ circle:nth-child(3) {
   padding: 10px;
   border-radius: 10px;
   margin-bottom: 16px;
-  max-width: 40%;
+  max-width: 60%;
   word-wrap: break-word;
 }
 
 .sent {
-  align-self: right;
+  align-self: flex-end;
   background-color: #c1e3ff;
   text-align: left;
   margin-left: auto;
 }
 
 .received {
-  align-items: right;
+  align-self: flex-start;
   background-color: rgb(230, 230, 230);
   text-align: left;
   margin-right: auto;

--- a/src/App.css
+++ b/src/App.css
@@ -75,18 +75,22 @@ circle:nth-child(3) {
   padding: 10px;
   border-radius: 10px;
   margin-bottom: 16px;
+  max-width: 40%;
+  word-wrap: break-word;
 }
 
 .sent {
-  align-items: right;
+  align-self: right;
   background-color: #c1e3ff;
-  text-align: right;
+  text-align: left;
+  margin-left: auto;
 }
 
 .received {
   align-items: right;
   background-color: rgb(230, 230, 230);
   text-align: left;
+  margin-right: auto;
 }
 
 .message__name {

--- a/src/Components/ChatPage.jsx
+++ b/src/Components/ChatPage.jsx
@@ -290,7 +290,7 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
 
   return (
     <div className="flex h-[100vh]">
-      <div className="w-[250px] h-[100vh] hidden xl:block lg:block md:block sm:block   bg-[#6674cc] items-center text-white  rounded-md bg- border ">
+      <div className="w-[250px] h-[100vh] hidden xl:block lg:block md:block sm:block  flex-shrink-0 bg-[#6674cc] items-center text-white  rounded-md bg- border ">
         <h2
           className="font-normal text-[20px] bg-[#eae4f6] text-richblack-900 p-[24px] flex items-center justify-between"
           onClick={() => {

--- a/src/Components/ChatPage.jsx
+++ b/src/Components/ChatPage.jsx
@@ -19,7 +19,7 @@ import MobileMenu from "./MobileMenu";
 import ShareBox from "./ShareBox";
 import { FaMicrophone, FaShare } from "react-icons/fa";
 import MicroPhone from "./MicroPhone";
-import Avatar from 'react-avatar';
+import Avatar from "react-avatar";
 
 // const socket = io('ws://localhost:8080/', { transports: ['websocket'] });
 
@@ -316,20 +316,16 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
                 justifyContent: "start",
                 alignItems: "center",
                 gap: "5px",
-                margin:'10px',
+                margin: "10px",
               }}
             >
-              <Avatar
-                size={40}
-                name={user.username}
-                round={true}
-              />
+              <Avatar size={40} name={user.username} round={true} />
               <div>
                 {user.username}
                 <div
                   style={{
                     color: "#2ecc71",
-                   fontWeight:'800'
+                    fontWeight: "800",
                   }}
                 >
                   Online
@@ -390,6 +386,7 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
                 username={msg.username}
                 createdAt={msg.createdAt}
                 url={msg.url}
+                isOwnMessage={msg.username === username} // checking if this message is from current user
               />
             ) : (
               <MessageTemplate
@@ -399,6 +396,7 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
                 username={msg.username}
                 createdAt={msg.createdAt}
                 message={msg.message}
+                isOwnMessage={msg.username === username} //same as above
               />
             )
           )}

--- a/src/Components/ChatPage.jsx
+++ b/src/Components/ChatPage.jsx
@@ -341,7 +341,7 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
       >
         <div
           id="messages"
-          className=" overflow-y-auto "
+          className="flex flex-col overflow-y-auto "
           ref={messagesContainerRef}
           style={{
             flexGrow: 1,

--- a/src/Components/ChatPage.jsx
+++ b/src/Components/ChatPage.jsx
@@ -336,7 +336,7 @@ const ChatPage = ({ darkMode, setDarkMode }) => {
         </ul>
       </div>
       <div
-        className=" flex  flex-col brosize  max-h-screen"
+        className="flex flex-col brosize pt-20 max-h-screen"
         style={{ flexGrow: 1 }}
       >
         <div

--- a/src/Components/LocationTemplate.jsx
+++ b/src/Components/LocationTemplate.jsx
@@ -1,19 +1,37 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import MapEmbed from './MapEmbed';
-const LocationTemplate = ({ username, createdAt, url,darkMode }) => {
- 
-
+import React from "react";
+import { Link } from "react-router-dom";
+import MapEmbed from "./MapEmbed";
+const LocationTemplate = ({
+  username,
+  createdAt,
+  url,
+  darkMode,
+  isOwnMessage,
+}) => {
   // console.log(username)
-  const limitedUsername = username.length> 10 ? username.slice(0, 10) + '...' : username;
+  const limitedUsername =
+    username.length > 10 ? username.slice(0, 10) + "..." : username;
   return (
-    <div className="message">
+    <div className={`message ${isOwnMessage ? "sent" : "received"}`}>
       <p>
-        <span className={`${darkMode ? 'text-white' : ' text-black'}  message__name`}>{limitedUsername}</span>
-        <span className="message__meta">{createdAt && createdAt.toString()}</span>
+        <span
+          className={`${
+            darkMode ? "text-white" : " text-black"
+          }  message__name`}
+        >
+          {limitedUsername}
+        </span>
+        <span className="message__meta">
+          {createdAt && createdAt.toString()}
+        </span>
       </p>
-      <p >
-        <Link to={url} target="_blank" rel="noopener noreferrer"  className={`${darkMode ? 'text-white' : ''}  text-caribbeangreen-400`}>
+      <p>
+        <Link
+          to={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${darkMode ? "text-white" : ""}  text-caribbeangreen-400`}
+        >
           My current location
         </Link>
       </p>

--- a/src/Components/MessageTemplate.jsx
+++ b/src/Components/MessageTemplate.jsx
@@ -1,16 +1,29 @@
-import React from 'react'
+import React from "react";
 
-const MessageTemplate = ({ username, createdAt, message,darkMode }) => {
-  const limitedUsername = username.length> 10 ? username.slice(0, 10) + '...' : username;
+const MessageTemplate = ({
+  username,
+  createdAt,
+  message,
+  darkMode,
+  isOwnMessage,
+}) => {
+  const limitedUsername =
+    username.length > 10 ? username.slice(0, 10) + "..." : username;
   return (
-    <div className="message">
-        <p>
-            <span className={`${darkMode ? 'text-white' : ' text-black'}  message__name`}>{limitedUsername}</span>
-            <span className="message__meta">{createdAt}</span>
-        </p>
-        <p className={`${darkMode ? 'text-white' : ' text-black'}`}>{message}</p>
-  </div>
-  )
-}
+    <div className={`message ${isOwnMessage ? "sent" : "received"}`}>
+      <p>
+        <span
+          className={`${
+            darkMode ? "text-white" : " text-black"
+          }  message__name`}
+        >
+          {limitedUsername}
+        </span>
+        <span className="message__meta">{createdAt}</span>
+      </p>
+      <p className={`${darkMode ? "text-white" : " text-black"}`}>{message}</p>
+    </div>
+  );
+};
 
-export default MessageTemplate
+export default MessageTemplate;

--- a/src/Components/MessageTemplate.jsx
+++ b/src/Components/MessageTemplate.jsx
@@ -14,14 +14,16 @@ const MessageTemplate = ({
       <p>
         <span
           className={`${
-            darkMode ? "text-white" : " text-black"
+            darkMode ? "text-richblack-700" : " text-black"
           }  message__name`}
         >
           {limitedUsername}
         </span>
         <span className="message__meta">{createdAt}</span>
       </p>
-      <p className={`${darkMode ? "text-white" : " text-black"}`}>{message}</p>
+      <p className={`${darkMode ? "text-customgrey" : " text-black"}`}>
+        {message}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Related Issue
This PR addresses issue no. #178 concerning the alignment and visual presentation of chat messages.

## Description
Sent messages will now appear on the right side of the chat window, while received messages will appear on the left side. A speech bubble style is added to provide clearer visual distinctions between sent and received messages. User experience is also enhanced in the dark mode improving readability and overall aesthetics of the app. 

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/urstrulynishkarsh/ReactChat/assets/89135704/6cd95d6d-9424-419e-bc04-99b0e22d745b)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
Along with the initial issue of changing message alignment, this PR also addresses additional UI/UX enhancements